### PR TITLE
Added Python 3 compatibility string

### DIFF
--- a/octoprint_PrinterAlerts/__init__.py
+++ b/octoprint_PrinterAlerts/__init__.py
@@ -46,6 +46,7 @@ class PrinterAlerts(octoprint.plugin.AssetPlugin,
 		)
 
 __plugin_name__ = "PrinterAlerts"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__


### PR DESCRIPTION
Seems all that was needed was the py3 compatibility string, so OctoPrint could load it. Full tested against the virtual printer, popups work as expected

Implements #6 